### PR TITLE
refactor-dao-apiexceptions-streamline

### DIFF
--- a/src/main/java/dat/Main.java
+++ b/src/main/java/dat/Main.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 
 public class Main
 {
-    final static EntityManagerFactory emf = HibernateConfig.getEntityManagerFactory();
+    public final static EntityManagerFactory emf = HibernateConfig.getEntityManagerFactory();
     final static MovieDAO movieDAO = MovieDAO.getInstance(emf);
     final static CreditDAO creditDAO = CreditDAO.getInstance(emf);
     final static GenreDAO genreDAO = GenreDAO.getInstance(emf);

--- a/src/main/java/dat/daos/CreditDAO.java
+++ b/src/main/java/dat/daos/CreditDAO.java
@@ -36,9 +36,10 @@ public class CreditDAO implements IDAO<Credit>
             em.persist(object);
             em.getTransaction().commit();
             return object;
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
-            throw new ApiException(401, "Error creating movie");
+            throw new ApiException(401, "Error creating credit. ", e);
         }
     }
 
@@ -53,6 +54,10 @@ public class CreditDAO implements IDAO<Credit>
             }
             em.getTransaction().commit();
         }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error creating credits ", e);
+        }
         return objects;
     }
 
@@ -64,7 +69,7 @@ public class CreditDAO implements IDAO<Credit>
         }
         catch (Exception e)
         {
-            throw new ApiException(401, "Error reading genre from db", e);
+            throw new ApiException(401, "Error reading credit from db", e);
         }
     }
     public Credit read(Credit object)
@@ -75,7 +80,7 @@ public class CreditDAO implements IDAO<Credit>
         }
         catch (Exception e)
         {
-            throw new ApiException(401, "Error reading genre from db", e);
+            throw new ApiException(401, "Error reading credit from db", e);
         }
 
     }
@@ -89,6 +94,10 @@ public class CreditDAO implements IDAO<Credit>
             em.merge(object);
             em.getTransaction().commit();
         }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error updating credit from db", e);
+        }
         return object;
     }
 
@@ -99,6 +108,10 @@ public class CreditDAO implements IDAO<Credit>
             em.getTransaction().begin();
             em.remove(id);
             em.getTransaction().commit();
+        }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error deleting credit from db", e);
         }
     }
 }

--- a/src/main/java/dat/daos/CreditDAO.java
+++ b/src/main/java/dat/daos/CreditDAO.java
@@ -91,14 +91,14 @@ public class CreditDAO implements IDAO<Credit>
         try (EntityManager em = emf.createEntityManager())
         {
             em.getTransaction().begin();
-            em.merge(object);
+            Credit updatedEntity = em.merge(object);
             em.getTransaction().commit();
+            return updatedEntity;
         }
         catch (Exception e)
         {
             throw new ApiException(401, "Error updating credit from db", e);
         }
-        return object;
     }
 
     public void delete(Long id)

--- a/src/main/java/dat/daos/CreditDAO.java
+++ b/src/main/java/dat/daos/CreditDAO.java
@@ -1,8 +1,6 @@
 package dat.daos;
 
-import dat.config.HibernateConfig;
 import dat.entities.Credit;
-import dat.entities.Genre;
 import dat.exceptions.ApiException;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
@@ -61,7 +59,7 @@ public class CreditDAO implements IDAO<Credit>
         return objects;
     }
 
-    public Credit read(int id)
+    public Credit read(Long id)
     {
         try (EntityManager em = emf.createEntityManager())
         {

--- a/src/main/java/dat/daos/GenreDAO.java
+++ b/src/main/java/dat/daos/GenreDAO.java
@@ -77,14 +77,14 @@ public class GenreDAO implements IDAO<Genre>
         try (EntityManager em = emf.createEntityManager())
         {
             em.getTransaction().begin();
-            em.merge(object);
+            Genre updatedEntity = em.merge(object);
             em.getTransaction().commit();
+            return updatedEntity;
         }
         catch (Exception e)
         {
             throw new ApiException(401, "Error updating genre", e);
         }
-        return object;
     }
 
     public void delete(Long id)

--- a/src/main/java/dat/daos/GenreDAO.java
+++ b/src/main/java/dat/daos/GenreDAO.java
@@ -34,9 +34,10 @@ public class GenreDAO implements IDAO<Genre>
             em.persist(object);
             em.getTransaction().commit();
             return object;
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
-            throw new ApiException(401, "Error creating movie");
+            throw new ApiException(401, "Error creating genre", e);
         }
     }
 
@@ -50,6 +51,10 @@ public class GenreDAO implements IDAO<Genre>
                 em.persist(object);
             }
             em.getTransaction().commit();
+        }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error creating genres", e);
         }
         return objects;
     }
@@ -75,6 +80,10 @@ public class GenreDAO implements IDAO<Genre>
             em.merge(object);
             em.getTransaction().commit();
         }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error updating genre", e);
+        }
         return object;
     }
 
@@ -85,6 +94,10 @@ public class GenreDAO implements IDAO<Genre>
             em.getTransaction().begin();
             em.remove(id);
             em.getTransaction().commit();
+        }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error deleting genre", e);
         }
     }
 }

--- a/src/main/java/dat/daos/GenreDAO.java
+++ b/src/main/java/dat/daos/GenreDAO.java
@@ -1,6 +1,5 @@
 package dat.daos;
 
-import dat.config.HibernateConfig;
 import dat.entities.Genre;
 import dat.exceptions.ApiException;
 import jakarta.persistence.EntityManager;
@@ -59,7 +58,7 @@ public class GenreDAO implements IDAO<Genre>
         return objects;
     }
 
-    public Genre read(int id)
+    public Genre read(Long id)
     {
         try (EntityManager em = emf.createEntityManager())
         {

--- a/src/main/java/dat/daos/IDAO.java
+++ b/src/main/java/dat/daos/IDAO.java
@@ -1,9 +1,43 @@
 package dat.daos;
 
+import dat.exceptions.ApiException;
+import jakarta.persistence.EntityManager;
+
+
+import static dat.Main.emf;
+
 public interface IDAO<T>
 {
-    T create(T t);
+    default T create(T object)
+    {
+        {
+            try (EntityManager em = emf.createEntityManager())
+            {
+                em.getTransaction().begin();
+                em.persist(object);
+                em.getTransaction().commit();
+                return object;
+            }
+            catch (Exception e)
+            {
+                throw new ApiException(401, "Error persisting object to db. ", e);
+            }
+        }
+    }
     T read(int id);
-    T update(T t);
+    default T update(T object)
+    {
+        try (EntityManager em = emf.createEntityManager())
+        {
+            em.getTransaction().begin();
+            T updated = em.merge(object);
+            em.getTransaction().commit();
+            return updated;
+        }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error updating object. ", e);
+        }
+    }
     void delete(Long id);
 }

--- a/src/main/java/dat/daos/IDAO.java
+++ b/src/main/java/dat/daos/IDAO.java
@@ -24,7 +24,7 @@ public interface IDAO<T>
             }
         }
     }
-    T read(int id);
+    T read(Long id);
     default T update(T object)
     {
         try (EntityManager em = emf.createEntityManager())

--- a/src/main/java/dat/daos/MovieDAO.java
+++ b/src/main/java/dat/daos/MovieDAO.java
@@ -83,13 +83,13 @@ public class MovieDAO implements IDAO<Movie>
         try (EntityManager em = emf.createEntityManager())
         {
             em.getTransaction().begin();
-            em.merge(object);
+            Movie updatedEntity = em.merge(object);
             em.getTransaction().commit();
+            return updatedEntity;
         } catch (Exception e)
         {
             throw new ApiException(401, "Error updating movie. ", e);
         }
-        return object;
     }
     @Override
     public void delete(Long id)

--- a/src/main/java/dat/daos/MovieDAO.java
+++ b/src/main/java/dat/daos/MovieDAO.java
@@ -6,6 +6,7 @@ import dat.exceptions.ApiException;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Query;
+import org.hibernate.exception.ConstraintViolationException;
 
 import java.util.List;
 
@@ -39,9 +40,12 @@ public class MovieDAO implements IDAO<Movie>
             em.persist(object);
             em.getTransaction().commit();
             return object;
+        } catch (ConstraintViolationException e)
+        {
+            throw new ApiException(403, "Error movie violates constraint, likely already exists.", e);
         } catch (Exception e)
         {
-            throw new ApiException(401, "Error creating movie");
+            throw new ApiException(401, "Error creating movie. ", e);
         }
     }
     public List<Movie> create(List<Movie> objects)
@@ -54,6 +58,9 @@ public class MovieDAO implements IDAO<Movie>
                 em.persist(object);
             }
             em.getTransaction().commit();
+        } catch (Exception e)
+        {
+            throw new ApiException(401, "Error creating movies. ", e);
         }
         return objects;
     }
@@ -71,6 +78,9 @@ public class MovieDAO implements IDAO<Movie>
             em.getTransaction().begin();
             em.merge(object);
             em.getTransaction().commit();
+        } catch (Exception e)
+        {
+            throw new ApiException(401, "Error updating movie. ", e);
         }
         return object;
     }
@@ -82,6 +92,9 @@ public class MovieDAO implements IDAO<Movie>
             em.getTransaction().begin();
             em.remove(id);
             em.getTransaction().commit();
+        } catch (Exception e)
+        {
+            throw new ApiException(401, "Error deleting movie. ", e);
         }
     }
 
@@ -96,9 +109,9 @@ public class MovieDAO implements IDAO<Movie>
             movies = query.getResultList();
             em.getTransaction().commit();
 
-        } catch (Exception e)
+        }  catch (Exception e)
         {
-            e.printStackTrace();
+            throw new ApiException(401, "Error reading movie. ", e);
         }
         return movies;
     }

--- a/src/main/java/dat/daos/MovieDAO.java
+++ b/src/main/java/dat/daos/MovieDAO.java
@@ -67,7 +67,14 @@ public class MovieDAO implements IDAO<Movie>
     @Override
     public Movie read(int id)
     {
-        return null;
+        try (EntityManager em = emf.createEntityManager())
+        {
+            return em.find(Movie.class, id);
+        }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error reading movie from db", e);
+        }
     }
 
     @Override

--- a/src/main/java/dat/daos/MovieDAO.java
+++ b/src/main/java/dat/daos/MovieDAO.java
@@ -1,14 +1,11 @@
 package dat.daos;
 
-import dat.entities.Genre;
 import dat.entities.Movie;
 import dat.exceptions.ApiException;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Query;
 import org.hibernate.exception.ConstraintViolationException;
-
-import java.util.List;
 
 import java.util.List;
 
@@ -65,7 +62,7 @@ public class MovieDAO implements IDAO<Movie>
         return objects;
     }
     @Override
-    public Movie read(int id)
+    public Movie read(Long id)
     {
         try (EntityManager em = emf.createEntityManager())
         {

--- a/src/main/java/dat/daos/SauronDAO.java
+++ b/src/main/java/dat/daos/SauronDAO.java
@@ -4,6 +4,7 @@ import dat.exceptions.ApiException;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class SauronDAO
@@ -90,6 +91,25 @@ public class SauronDAO
             T updatedEntity = em.merge(object);
             em.getTransaction().commit();
             return updatedEntity;
+        }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error updating object. ", e);
+        }
+    }
+
+    public <T> List<T> update(List<T> objects)
+    {
+        try (EntityManager em = emf.createEntityManager())
+        {
+            List<T> updatedObjects = new ArrayList<>();
+            em.getTransaction().begin();
+            for (T object : objects)
+            {
+                updatedObjects.add(em.merge(object));
+            }
+            em.getTransaction().commit();
+            return updatedObjects;
         }
         catch (Exception e)
         {

--- a/src/main/java/dat/daos/SauronDAO.java
+++ b/src/main/java/dat/daos/SauronDAO.java
@@ -1,0 +1,128 @@
+package dat.daos;
+
+import dat.exceptions.ApiException;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import java.util.List;
+
+public class SauronDAO
+{
+    private static EntityManagerFactory emf;
+    private static SauronDAO instance;
+
+    private SauronDAO(EntityManagerFactory emf)
+    {
+        this.emf = emf;
+    }
+
+    public static SauronDAO getInstance(EntityManagerFactory emf)
+    {
+        if (instance == null)
+        {
+            instance = new SauronDAO(emf);
+        }
+        return instance;
+    }
+
+    public <T> T create(T object)
+    {
+        try (EntityManager em = emf.createEntityManager())
+        {
+            em.getTransaction().begin();
+            em.persist(object);
+            em.getTransaction().commit();
+            return object;
+        }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error persisting object to db. ", e);
+        }
+    }
+
+    public <T> List<T> create(List<T> objects)
+    {
+        try (EntityManager em = emf.createEntityManager())
+        {
+            em.getTransaction().begin();
+            for (T object : objects)
+            {
+                em.persist(object);
+            }
+            em.getTransaction().commit();
+            return objects;
+        }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error persisting object to db. ", e);
+        }
+    }
+
+    public <T> T read(Class<T> type, int id)
+    {
+        try (EntityManager em = emf.createEntityManager())
+        {
+            return em.find(type, id);
+        }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error reading object from db", e);
+        }
+    }
+
+    public <T> List<T> findAll(Class<T> type)
+    {
+        try (EntityManager em = emf.createEntityManager())
+        {
+            return em.createQuery("SELECT t FROM " + type.getSimpleName() + " t", type).getResultList();
+        }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error reading objects from db", e);
+        }
+    }
+
+    public <T> T update(T object)
+    {
+        try (EntityManager em = emf.createEntityManager())
+        {
+            em.getTransaction().begin();
+            T updatedEntity = em.merge(object);
+            em.getTransaction().commit();
+            return updatedEntity;
+        }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error updating object. ", e);
+        }
+    }
+
+    public <T> void delete(T object)
+    {
+        try (EntityManager em = emf.createEntityManager())
+        {
+            em.getTransaction().begin();
+            em.remove(object);
+            em.getTransaction().commit();
+        }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error deleting object. ", e);
+        }
+    }
+
+    public <T> void delete(Class<T> type, int id)
+    {
+        try (EntityManager em = emf.createEntityManager())
+        {
+            em.getTransaction().begin();
+            T object = em.find(type, id);
+            em.remove(object);
+            em.getTransaction().commit();
+        }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error deleting object. ", e);
+        }
+    }
+}

--- a/src/main/java/dat/daos/SauronDAO.java
+++ b/src/main/java/dat/daos/SauronDAO.java
@@ -1,5 +1,6 @@
 package dat.daos;
 
+import dat.entities.Movie;
 import dat.exceptions.ApiException;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
@@ -143,6 +144,75 @@ public class SauronDAO
         catch (Exception e)
         {
             throw new ApiException(401, "Error deleting object. ", e);
+        }
+    }
+
+    public List<Movie> getMoviesByTitle(String title)
+    {
+        try (EntityManager em = emf.createEntityManager())
+        {
+            return em.createQuery("SELECT m FROM Movie m WHERE m.title LIKE :title", Movie.class)
+                    .setParameter("title", "%" + title + "%")
+                    .getResultList();
+        }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error reading object from db", e);
+        }
+    }
+
+    public Double getTotalAverageRating()
+    {
+        try (EntityManager em = emf.createEntityManager())
+        {
+            return em.createQuery("SELECT AVG(m.rating) FROM Movie m", Double.class)
+                    .getSingleResult();
+        }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error reading object from db", e);
+        }
+    }
+
+    public List<Movie> getTop10Movies()
+    {
+        try (EntityManager em = emf.createEntityManager())
+        {
+            return em.createQuery("SELECT m FROM Movie m ORDER BY m.rating DESC", Movie.class)
+                    .setMaxResults(10)
+                    .getResultList();
+        }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error reading object from db", e);
+        }
+    }
+
+    public List<Movie> getBot10Movies()
+    {
+        try (EntityManager em = emf.createEntityManager())
+        {
+            return em.createQuery("SELECT m FROM Movie m ORDER BY m.rating ASC", Movie.class)
+                    .setMaxResults(10)
+                    .getResultList();
+        }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error reading object from db", e);
+        }
+    }
+
+    public List<Movie> getPopularMovies()
+    {
+        try (EntityManager em = emf.createEntityManager())
+        {
+            return em.createQuery("SELECT m FROM Movie m ORDER BY m.popularity DESC", Movie.class)
+                    .setMaxResults(10)
+                    .getResultList();
+        }
+        catch (Exception e)
+        {
+            throw new ApiException(401, "Error reading object from db", e);
         }
     }
 }


### PR DESCRIPTION
Jeg synes at det er fjollet at have tre praktisk talt ens DAO klasser, med nøjagtig den samme fejl i alle deres update metoder! Og inkonsekvent brug af catch og throw ApiException!
Enten skal der laves en default implementation af create og update i interfacet, så slipper vi for ca 3 x 30 linjers gentaget kode. Eller også skal vi bare have en DAO klasse som kan styre det hele. 